### PR TITLE
Allow key combinations in addition to single keys

### DIFF
--- a/buttons.js
+++ b/buttons.js
@@ -62,7 +62,7 @@
         if (config.hotkey) {
             var map = {};
             map[config.hotkey] = config.callback;
-            cm.addKeyMap(map);
+            cm.addKeyMap(CodeMirror.normalizeKeyMap(map));
         }
 
         return buttonNode;


### PR DESCRIPTION
Uses the CodeMirror.normalizeKeyMap() function to allow key combinations, e.g. 'Ctrl-K Ctrl-D', as well as single keys